### PR TITLE
refactor: Remove ignore use_build_context_synchronously

### DIFF
--- a/lib/src/features/account/profile/view/profile_view.dart
+++ b/lib/src/features/account/profile/view/profile_view.dart
@@ -43,7 +43,6 @@ class ProfileView extends StatelessWidget {
                 final result =
                     await context.read<AccountBloc>().onLogOut(context);
                 if (result == true) {
-                  // ignore: use_build_context_synchronously
                   AppCoordinator.pop();
                 }
               },
@@ -60,7 +59,6 @@ class ProfileView extends StatelessWidget {
                 final result =
                     await context.read<AccountBloc>().onRemoveAccount(context);
                 if (result == true) {
-                  // ignore: use_build_context_synchronously
                   AppCoordinator.pop();
                 }
               },

--- a/lib/src/features/authentication/logic/forgot_state.dart
+++ b/lib/src/features/authentication/logic/forgot_state.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first
 part of 'forgot_bloc.dart';
 
 class ForgotState extends Equatable {

--- a/lib/src/features/authentication/logic/signin_bloc.dart
+++ b/lib/src/features/authentication/logic/signin_bloc.dart
@@ -1,21 +1,17 @@
-// ignore_for_file: use_build_context_synchronously
-
 import 'package:equatable/equatable.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
 import 'package:myapp/src/dialogs/alert_wrapper.dart';
 import 'package:myapp/src/features/account/logic/account_bloc.dart';
 import 'package:myapp/src/features/authentication/model/email_fromz.dart';
 import 'package:myapp/src/features/authentication/model/model_input.dart';
+import 'package:myapp/src/network/model/common/result.dart';
 import 'package:myapp/src/network/model/social_type.dart';
 import 'package:myapp/src/network/domain_manager.dart';
 import 'package:formz/formz.dart';
 import 'package:myapp/src/network/model/social_user/social_user.dart';
 import 'package:myapp/src/network/model/user/user.dart';
 import 'package:myapp/src/router/coordinator.dart';
-
-import '../../../network/model/common/result.dart';
 
 part 'signin_state.dart';
 
@@ -24,7 +20,7 @@ class SigninBloc extends Cubit<SigninState> {
 
   DomainManager get domain => DomainManager();
 
-  Future loginWithEmail(BuildContext context) async {
+  Future loginWithEmail() async {
     if (state.status.isInProgress) return;
     if (state.isValidated == false) {
       return;
@@ -37,49 +33,49 @@ class SigninBloc extends Cubit<SigninState> {
     final password = state.password.value;
     final result =
         await domain.sign.loginWithEmail(email: email, password: password);
-    return loginDecision(context, result);
+    return loginDecision(result);
   }
 
-  Future loginWithGoogle(BuildContext context) async {
+  Future loginWithGoogle() async {
     if (state.status.isInProgress) return;
     emit(state.copyWith(
       status: FormzSubmissionStatus.inProgress,
       loginType: MSocialType.google,
     ));
     final result = await domain.sign.loginWithGoogle();
-    return loginSocialDecision(context, result, MSocialType.google);
+    return loginSocialDecision(result, MSocialType.google);
   }
 
-  Future loginWithApple(BuildContext context) async {
+  Future loginWithApple() async {
     if (state.status.isInProgress) return;
     emit(state.copyWith(
       status: FormzSubmissionStatus.inProgress,
       loginType: MSocialType.apple,
     ));
     final result = await domain.sign.loginWithApple();
-    return loginSocialDecision(context, result, MSocialType.apple);
+    return loginSocialDecision(result, MSocialType.apple);
   }
 
-  Future loginWithFacebook(BuildContext context) async {
+  Future loginWithFacebook() async {
     if (state.status.isInProgress) return;
     emit(state.copyWith(
       status: FormzSubmissionStatus.inProgress,
       loginType: MSocialType.facebook,
     ));
     final result = await domain.sign.loginWithFacebook();
-    return loginSocialDecision(context, result, MSocialType.facebook);
+    return loginSocialDecision(result, MSocialType.facebook);
   }
 
-  Future loginSocialDecision(BuildContext context, MResult<MSocialUser> result,
-      MSocialType socialType) async {
+  Future loginSocialDecision(
+      MResult<MSocialUser> result, MSocialType socialType) async {
     if (result.isSuccess) {
       final data = result.data!;
       if (socialType == MSocialType.google) {
-        connectBEWithGoogle(context, data);
+        connectBEWithGoogle(data);
       } else if (socialType == MSocialType.facebook) {
-        connectBEWithFacebook(context, data);
+        connectBEWithFacebook(data);
       } else if (socialType == MSocialType.apple) {
-        connectBEWithApple(context, data);
+        connectBEWithApple(data);
       }
     } else {
       emit(state.copyWith(status: FormzSubmissionStatus.failure));
@@ -87,23 +83,22 @@ class SigninBloc extends Cubit<SigninState> {
     }
   }
 
-  Future connectBEWithGoogle(BuildContext context, MSocialUser user) async {
+  Future connectBEWithGoogle(MSocialUser user) async {
     final result = await domain.sign.connectBEWithGoogle(user);
-    return loginDecision(context, result, socialType: user.type);
+    return loginDecision(result, socialType: user.type);
   }
 
-  Future connectBEWithFacebook(BuildContext context, MSocialUser user) async {
+  Future connectBEWithFacebook(MSocialUser user) async {
     final result = await domain.sign.connectBEWithFacebook(user);
-    return loginDecision(context, result, socialType: user.type);
+    return loginDecision(result, socialType: user.type);
   }
 
-  Future connectBEWithApple(BuildContext context, MSocialUser user) async {
+  Future connectBEWithApple(MSocialUser user) async {
     final result = await domain.sign.connectBEWithApple(user);
-    return loginDecision(context, result, socialType: user.type);
+    return loginDecision(result, socialType: user.type);
   }
 
-  Future loginDecision(BuildContext context, MResult<MUser> result,
-      {MSocialType? socialType}) async {
+  Future loginDecision(MResult<MUser> result, {MSocialType? socialType}) async {
     if (result.isSuccess) {
       emit(state.copyWith(status: FormzSubmissionStatus.success));
       GetIt.I<AccountBloc>().onLoginSuccess(result.data!);

--- a/lib/src/features/authentication/logic/signin_state.dart
+++ b/lib/src/features/authentication/logic/signin_state.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first
 part of 'signin_bloc.dart';
 
 class SigninState extends Equatable {

--- a/lib/src/features/authentication/logic/signup_bloc.dart
+++ b/lib/src/features/authentication/logic/signup_bloc.dart
@@ -33,8 +33,9 @@ class SignupBloc extends Cubit<SignupState> {
         .signUpWithEmail(email: email, password: password, name: name);
     if (result.isSuccess) {
       emit(state.copyWith(status: FormzSubmissionStatus.inProgress));
-      // ignore: use_build_context_synchronously
-      signupDecision(context, result.data!);
+      if (context.mounted) {
+        signupDecision(context, result.data!);
+      }
     } else {
       emit(state.copyWith(status: FormzSubmissionStatus.failure));
       XAlert.show(title: 'Signup fail', body: result.error);

--- a/lib/src/features/authentication/view/signin_view.dart
+++ b/lib/src/features/authentication/view/signin_view.dart
@@ -73,7 +73,7 @@ class SigninView extends StatelessWidget {
           enabled: state.isValidated,
           title: S.of(context).common_next,
           onPressed: () async {
-            context.read<SigninBloc>().loginWithEmail(context);
+            context.read<SigninBloc>().loginWithEmail();
           },
         ),
         const SizedBox(height: 32.0),

--- a/lib/src/features/authentication/widget/social_list_button.dart
+++ b/lib/src/features/authentication/widget/social_list_button.dart
@@ -29,8 +29,7 @@ class SocialListButton extends StatelessWidget {
                 title: S.of(context).sign_signin_signinWithApple,
                 busy: state.status.isInProgress &&
                     state.loginType == MSocialType.apple,
-                onPressed: () =>
-                    context.read<SigninBloc>().loginWithApple(context),
+                onPressed: () => context.read<SigninBloc>().loginWithApple(),
               ),
             ],
             space,
@@ -39,8 +38,7 @@ class SocialListButton extends StatelessWidget {
               title: S.of(context).sign_signin_signinWithFacebook,
               busy: state.status.isInProgress &&
                   state.loginType == MSocialType.facebook,
-              onPressed: () =>
-                  context.read<SigninBloc>().loginWithFacebook(context),
+              onPressed: () => context.read<SigninBloc>().loginWithFacebook(),
             ),
             space,
             _buildButton(
@@ -48,8 +46,7 @@ class SocialListButton extends StatelessWidget {
               title: S.of(context).sign_signin_signinWithGoogle,
               busy: state.status.isInProgress &&
                   state.loginType == MSocialType.google,
-              onPressed: () =>
-                  context.read<SigninBloc>().loginWithGoogle(context),
+              onPressed: () => context.read<SigninBloc>().loginWithGoogle(),
             ),
           ],
         );

--- a/lib/src/localization/localization_utils.dart
+++ b/lib/src/localization/localization_utils.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart' as al;
 import 'package:myapp/src/router/coordinator.dart';
 
-// ignore: avoid_classes_with_only_static_members
 class S {
   static get delegate => al.AppLocalizations.delegate;
   static get localizationsDelegates =>

--- a/lib/src/network/blob/data/upload_repository_impl.dart
+++ b/lib/src/network/blob/data/upload_repository_impl.dart
@@ -1,4 +1,3 @@
-// ignore: depend_on_referenced_packages
 import 'package:http_parser/http_parser.dart' as http_parser;
 import '../../model/common/result.dart';
 import '../model/upload_model.dart';

--- a/lib/src/network/blob/model/upload_model.dart
+++ b/lib/src/network/blob/model/upload_model.dart
@@ -1,4 +1,3 @@
-// ignore: unused_import
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/lib/src/network/model/common/pagination/meta/pagination_meta.dart
+++ b/lib/src/network/model/common/pagination/meta/pagination_meta.dart
@@ -1,4 +1,3 @@
-// ignore: unused_import
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 

--- a/lib/widgets/button/model/button_size.dart
+++ b/lib/widgets/button/model/button_size.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first
-
 import 'package:flutter/material.dart';
 
 class ButtonSize {

--- a/lib/widgets/forms/multi_text_field.dart
+++ b/lib/widgets/forms/multi_text_field.dart
@@ -110,7 +110,6 @@ class XMultiTextField extends StatelessWidget {
     );
   }
 
-  // ignore: avoid_field_initializers_in_const_classes
   final _textController = TextEditingController();
 
   Future _showAddItem(BuildContext context) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -750,7 +750,7 @@ packages:
     source: hosted
     version: "3.2.1"
   http_parser:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http_parser
       sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   permission_handler: ^10.4.5
   share_plus: ^7.2.1
   validators: ^3.0.0
+  http_parser: ^4.0.2
 
   # WIDGET
   photo_view: ^0.14.0


### PR DESCRIPTION
## Todo
- [x] Remove ignore use_build_context_synchronously
- [x] Remove some other ignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `http_parser` dependency to enhance network capabilities.

- **Refactor**
  - Improved logout and account removal flow in the profile view.
  - Streamlined authentication logic by removing unused imports and context parameters.
  - Enhanced error handling in social login decision processes.
  - Updated the authentication view to align with refactored logic, removing unnecessary context passing.
  - Adjusted social list button actions to match updated authentication methods.

- **Chores**
  - Removed unused import statements across various files to clean up the codebase.
  - Eliminated outdated or unnecessary compiler directives to adhere to best practices.

- **Documentation**
  - Removed commented-out code and directives that were no longer needed, clarifying the code's intent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->